### PR TITLE
It’s NSPhotoLibraryAddUsageDescription

### DIFF
--- a/project13/Project13/Info.plist
+++ b/project13/Project13/Info.plist
@@ -20,7 +20,7 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSPhotoLibraryUsageDescription</key>
+	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>We need to import photos.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
Running "Chapter 13" on Xcode Version 9.1 (9B55) for iOS 11 and clicking the Save button results in "[access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSPhotoLibraryAddUsageDescription key with a string value explaining to the user how the app uses this data."

In the Simulator be sure to select Hardware > "Erase All Content and Settings..." to see this behavior. Once access has been granted - this issue won't reappear.

In Info.plist, change NSPhotoLibraryUsageDescription to NSPhotoLibraryAddUsageDescription (The word Add is in there). "Include the NSPhotoLibraryAddUsageDescription key (in apps that link on or after iOS 11)" More information [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW73)