### PR TITLE
Project 22 - (Classic).  Update to Swift 5.0 and iOS 13.  Replaced deprecated CLBeaconRegion with updated one.

### DIFF
--- a/Classic/project22/Project22.xcodeproj/project.pbxproj
+++ b/Classic/project22/Project22.xcodeproj/project.pbxproj
@@ -91,20 +91,19 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = "Paul Hudson";
 				TargetAttributes = {
 					5140D9EA1D670341006B6CEA = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = B5C26XE59E;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1240;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = 5140D9E61D670341006B6CEA /* Build configuration list for PBXProject "Project22" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -169,6 +168,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -189,6 +189,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -227,6 +228,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -247,6 +249,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -278,13 +281,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Project22/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.Project22;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -292,13 +296,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = B5C26XE59E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Project22/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.Project22;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Classic/project22/Project22/ViewController.swift
+++ b/Classic/project22/Project22/ViewController.swift
@@ -36,19 +36,17 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
 
 	func startScanning() {
 		let uuid = UUID(uuidString: "5A4BCFCE-174E-4BAC-A814-092E77F6B7E5")!
-		let beaconRegion = CLBeaconRegion(proximityUUID: uuid, major: 123, minor: 456, identifier: "MyBeacon")
-
-		locationManager.startMonitoring(for: beaconRegion)
-		locationManager.startRangingBeacons(in: beaconRegion)
+        let beaconIDConstraint = CLBeaconIdentityConstraint(uuid: uuid, major: CLBeaconMajorValue(123), minor: CLBeaconMinorValue(456))
+        let beaconRegion = CLBeaconRegion(beaconIdentityConstraint: beaconIDConstraint, identifier: "MyBeacon")
+        
+        locationManager?.startMonitoring(for: beaconRegion)
+        locationManager?.startRangingBeacons(satisfying: beaconIDConstraint)
 	}
 
 	func update(distance: CLProximity) {
 		UIView.animate(withDuration: 0.8) { [unowned self] in
 			switch distance {
-			case .unknown:
-				self.view.backgroundColor = UIColor.gray
-				self.distanceReading.text = "UNKNOWN"
-
+            
 			case .far:
 				self.view.backgroundColor = UIColor.blue
 				self.distanceReading.text = "FAR"
@@ -60,6 +58,10 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
 			case .immediate:
 				self.view.backgroundColor = UIColor.red
 				self.distanceReading.text = "RIGHT HERE"
+                
+            default:
+                self.view.backgroundColor = UIColor.gray
+                self.distanceReading.text = "UNKNOWN"
 			}
 		}
 	}

--- a/Classic/project22/Project22/ViewController.swift
+++ b/Classic/project22/Project22/ViewController.swift
@@ -36,6 +36,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
 
 	func startScanning() {
 		let uuid = UUID(uuidString: "5A4BCFCE-174E-4BAC-A814-092E77F6B7E5")!
+        
         let beaconIDConstraint = CLBeaconIdentityConstraint(uuid: uuid, major: CLBeaconMajorValue(123), minor: CLBeaconMinorValue(456))
         let beaconRegion = CLBeaconRegion(beaconIdentityConstraint: beaconIDConstraint, identifier: "MyBeacon")
         


### PR DESCRIPTION
Replaced CLBeaconRegion with updated version that uses CLBeaconIdentityConstraint which in turn uses CLBeaconMajorValue and CLBeaconMinorValue.  Tested against iOS 13.0 and iOS 14.4.