### PR TITLE
iOS 14.0 header uppercase problem

### DIFF
--- a/SwiftUI/project1/Project1/ContentView.swift
+++ b/SwiftUI/project1/Project1/ContentView.swift
@@ -47,6 +47,7 @@ struct ContentView: View {
                             Text("\(self.tipPercentages[$0])%")
                         }
                     }
+                    .textCase(nil)
                     .pickerStyle(SegmentedPickerStyle())
                 }
 


### PR DESCRIPTION
With the new update (I don't know why) iOS automatically capitalizes all headers. To avoid this you need to add .textCase (nil)