### PR TITLE
Move dynamic tab bar item configuration code to SceneDelegate.swift

### DIFF
--- a/Classic/project7/Project7/AppDelegate.swift
+++ b/Classic/project7/Project7/AppDelegate.swift
@@ -15,12 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-		if let tabBarController = window?.rootViewController as? UITabBarController {
-			let storyboard = UIStoryboard(name: "Main", bundle: nil)
-			let vc = storyboard.instantiateViewController(withIdentifier: "NavController")
-			vc.tabBarItem = UITabBarItem(tabBarSystemItem: .topRated, tag: 1)
-			tabBarController.viewControllers?.append(vc)
-		}
+		
 
 		return true
 	}

--- a/Classic/project7/Project7/SceneDelegate.swift
+++ b/Classic/project7/Project7/SceneDelegate.swift
@@ -1,0 +1,60 @@
+//
+//  SceneDelegate.swift
+//  Project8
+//
+//  Created by gtxtreme on 16/08/22.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        if let tabBarController = window?.rootViewController as? UITabBarController {
+            let storyBoard = UIStoryboard(name: "Main", bundle: nil)
+            let vc = storyBoard.instantiateViewController(withIdentifier: "NavController")
+            vc.tabBarItem = UITabBarItem(tabBarSystemItem: .topRated, tag: 1)
+            tabBarController.viewControllers?.append(vc)
+            print("Count:\(tabBarController.viewControllers?.count ?? 0)")
+        }
+        
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+


### PR DESCRIPTION
For IOS 13+ `AppDelegate`'s  `didFinishLaunchingWithOptions` might return `nil` so moving the tab bar item dynamic configuration code to `SceneDelegate`'s `willConnectTo` `session` method instead

Related SO issue

https://stackoverflow.com/questions/65932261/cant-add-viewcontoller-to-tab-bar-programmatically-in-the-appdelegate