### PR TITLE
Add .allowsHitTesting(false) to the center circle so that the user can select a marker that is underneath it

### DIFF
--- a/SwiftUI/project14/Bucketlist/ContentView.swift
+++ b/SwiftUI/project14/Bucketlist/ContentView.swift
@@ -38,6 +38,7 @@ struct ContentView: View {
                     .fill(.blue)
                     .opacity(0.3)
                     .frame(width: 32, height: 32)
+                    .allowsHitTesting(false)
 
                 VStack {
                     Spacer()


### PR DESCRIPTION
In project 14 of the Hacking With Swift series I noticed that once I added an annotation to the map I was unable to select it for editing because the center circle was intercepting touches. A minor deficiency albeit, I thought it was worth adding this small change to addresses it.